### PR TITLE
Introduce subtle Rosewood rumors feature

### DIFF
--- a/src/ChallengeManager.js
+++ b/src/ChallengeManager.js
@@ -3,6 +3,7 @@ import './ChallengeManager.css';
 import TreasureChest from './TreasureChest';
 import LocationTracker from './LocationTracker';
 import DailyEmojiGuesser from './DailyEmojiGuesser';
+import RosewoodRumor from './RosewoodRumor';
 
 const ChallengeManager = () => {
   const [locationStage, setLocationStage] = useState(0);
@@ -77,6 +78,9 @@ const ChallengeManager = () => {
       <div className="daily-game-section">
         <DailyEmojiGuesser />
       </div>
+
+      {/* Rosewood Rumors */}
+      <RosewoodRumor />
 
       {/* Location Tracker - Journey Progress */}
       <div className="journey-section">

--- a/src/RosewoodRumor.css
+++ b/src/RosewoodRumor.css
@@ -1,0 +1,23 @@
+.rosewood-rumor {
+  background: linear-gradient(135deg, rgba(60, 20, 40, 0.9), rgba(40, 10, 30, 0.8));
+  border-radius: 12px;
+  padding: 20px;
+  margin: 20px 0;
+  border: 2px solid #c71585;
+  color: #ffe6f0;
+  text-align: center;
+  box-shadow: 0 0 20px rgba(199, 21, 133, 0.3);
+}
+
+.rosewood-rumor-title {
+  color: #ff8acc;
+  font-size: 24px;
+  margin-bottom: 10px;
+  font-family: 'Cinzel', serif;
+  text-shadow: 0 0 8px rgba(199, 21, 133, 0.6);
+}
+
+.rosewood-rumor-text {
+  font-size: 16px;
+  line-height: 1.4;
+}

--- a/src/RosewoodRumor.js
+++ b/src/RosewoodRumor.js
@@ -1,0 +1,33 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import './RosewoodRumor.css';
+
+const RosewoodRumor = () => {
+  const facts = useMemo(
+    () => [
+      "A certain clique in Rosewood can't seem to escape trouble.",
+      'Anonymous messages hold more weight than gossip in this small town.',
+      "The bell tower has witnessed more drama than most places in Rosewood.",
+      'Masked gatherings rarely end calmly here.',
+      'Secrets buried in Rosewood never stay hidden for long.',
+      'Mysterious texts keep everyone guessing.',
+      "Friendships are tested daily in Rosewood's halls.",
+      'Every clue brings an A-plus puzzle with it.'
+    ],
+    []
+  );
+
+  const [rumor, setRumor] = useState('');
+
+  useEffect(() => {
+    setRumor(facts[Math.floor(Math.random() * facts.length)]);
+  }, [facts]);
+
+  return (
+    <div className="rosewood-rumor">
+      <h3 className="rosewood-rumor-title">Rosewood Rumor</h3>
+      <p className="rosewood-rumor-text">{rumor}</p>
+    </div>
+  );
+};
+
+export default RosewoodRumor;


### PR DESCRIPTION
## Summary
- replace obvious PLL trivia with subtle **RosewoodRumor** component
- style the rumor section via `RosewoodRumor.css`
- integrate `RosewoodRumor` in the ChallengeManager

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7e57ff9c8323a07be80f37cb61d7