### PR TITLE
Add Rosewood glitch transition

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -304,6 +304,18 @@ body {
   margin-top: 4px;
 }
 
+.glitch-transition {
+  animation: shortGlitch 0.3s;
+}
+
+@keyframes shortGlitch {
+  0% { opacity: 1; transform: translateX(0); }
+  25% { opacity: 0.4; transform: translateX(-2px); }
+  50% { opacity: 0.8; transform: translateX(2px); }
+  75% { opacity: 0.6; transform: translateX(-1px); }
+  100% { opacity: 1; transform: translateX(0); }
+}
+
 /* Cart and treasure animations */
 @keyframes treasureFlag {
   0% {

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,8 @@ function App() {
   const [progress, setProgress] = useState(75);
   const [daysLeft, setDaysLeft] = useState(0);
   const [locationStage, setLocationStage] = useState(0);
+  const [watcherMessage, setWatcherMessage] = useState('Rosewood is watching. -A');
+  const [watcherGlitch, setWatcherGlitch] = useState(false);
 
   // Calculate progress based on location stage
   const calculateLocationProgress = (stage) => {
@@ -32,6 +34,17 @@ function App() {
     const timer = setInterval(updateTimings, 60000);
 
     return () => clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    const glitchTimer = setTimeout(() => {
+      setWatcherGlitch(true);
+      setTimeout(() => {
+        setWatcherMessage('Lido Adriano is watching. -A');
+        setWatcherGlitch(false);
+      }, 200);
+    }, 1500);
+    return () => clearTimeout(glitchTimer);
   }, []);
 
   // Initialize completed stages
@@ -87,7 +100,7 @@ function App() {
         {daysLeft > 0 && (
           <>
             <div className="a-comment">tick-tock</div>
-            <div className="a-comment">Rosewood is watching. -A</div>
+            <div className={`a-comment ${watcherGlitch ? 'glitch-transition' : ''}`}>{watcherMessage}</div>
           </>
         )}
       </header>

--- a/src/GlitchingMessages.js
+++ b/src/GlitchingMessages.js
@@ -6,6 +6,13 @@ const GlitchingMessages = () => {
   const [visible, setVisible] = useState(false);
   const [currentMessage, setCurrentMessage] = useState('');
   const [glitchClass, setGlitchClass] = useState('');
+  const glitchTransitions = useMemo(
+    () => ({
+      "rosewood's secrets always surface. -A": "Lido Adriano's secrets always surface. -A",
+      "meet me in Rosewood's town square. -A": "meet me in Lido Adriano's town square. -A",
+    }),
+    []
+  );
 
   // Billie Eilish song title wordplay with a dash of A's warnings - wrapped in useMemo
   const messages = useMemo(() => [
@@ -115,10 +122,20 @@ const GlitchingMessages = () => {
       // Select random message
       const randomMessage = messages[Math.floor(Math.random() * messages.length)];
       setCurrentMessage(randomMessage);
-      
+
       // Show with glitch effect
       setGlitchClass('glitch-in');
       setVisible(true);
+
+      if (glitchTransitions[randomMessage]) {
+        setTimeout(() => {
+          setGlitchClass('glitch-out');
+          setTimeout(() => {
+            setCurrentMessage(glitchTransitions[randomMessage]);
+            setGlitchClass('glitch-in');
+          }, 150);
+        }, 700);
+      }
       
       // Set timeout to remove after random duration (1.5-5 seconds) - shorter durations for quicker turnover
       setTimeout(() => {
@@ -129,7 +146,7 @@ const GlitchingMessages = () => {
         }, 1000);
       }, Math.random() * 3500 + 1500);
     }
-  }, [visible, messages]);
+  }, [visible, messages, glitchTransitions]);
 
   useEffect(() => {
     // Check for showing/hiding message every 1.5-5 seconds (more frequent)


### PR DESCRIPTION
## Summary
- bring back Rosewood references
- add glitch effect that changes Rosewood messages to Lido Adriano

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c80a3f3d48323bcbea4c0fb9b7283