### PR TITLE
Add color variation for glitch messages

### DIFF
--- a/src/GlitchingMessages.css
+++ b/src/GlitchingMessages.css
@@ -1,7 +1,7 @@
 .glitching-message {
   position: fixed;
   font-family: 'Courier New', monospace;
-  color: #bdbde2;
+  color: var(--message-color, #bdbde2);
   font-size: 14px;
   letter-spacing: 0.5px;
   text-transform: lowercase;
@@ -11,7 +11,7 @@
   box-shadow: 0 0 5px rgba(106, 106, 219, 0.3);
   z-index: 1000;
   pointer-events: none;
-  text-shadow: 0 0 2px rgba(106, 106, 219, 0.5);
+  text-shadow: 0 0 2px var(--message-color, rgba(106, 106, 219, 0.5));
   opacity: 0;
   transform: translateY(0);
 }
@@ -142,6 +142,7 @@
     opacity: 0;
     z-index: -1;
     transform: translateX(-5px);
+    color: var(--message-color, #bdbde2);
     animation: glitchText 0.3s ease infinite alternate-reverse;
   }
   
@@ -156,6 +157,7 @@
     opacity: 0;
     z-index: -1;
     transform: translateX(5px);
+    color: var(--message-color, #bdbde2);
     animation: glitchText 0.3s ease 0.1s infinite alternate-reverse;
   }
   

--- a/src/GlitchingMessages.js
+++ b/src/GlitchingMessages.js
@@ -6,6 +6,17 @@ const GlitchingMessages = () => {
   const [visible, setVisible] = useState(false);
   const [currentMessage, setCurrentMessage] = useState('');
   const [glitchClass, setGlitchClass] = useState('');
+  const colorOptions = useMemo(
+    () => [
+      '#ff5bde',
+      '#22d3ee',
+      '#facc15',
+      '#34d399',
+      '#a78bfa'
+    ],
+    []
+  );
+  const [messageColor, setMessageColor] = useState(colorOptions[0]);
   const glitchTransitions = useMemo(
     () => ({
       "rosewood's secrets always surface. -A": "Lido Adriano's secrets always surface. -A",
@@ -123,6 +134,15 @@ const GlitchingMessages = () => {
       const randomMessage = messages[Math.floor(Math.random() * messages.length)];
       setCurrentMessage(randomMessage);
 
+      // Choose a new color different from the last one
+      if (colorOptions.length > 1) {
+        let nextColor = messageColor;
+        while (nextColor === messageColor) {
+          nextColor = colorOptions[Math.floor(Math.random() * colorOptions.length)];
+        }
+        setMessageColor(nextColor);
+      }
+
       // Show with glitch effect
       setGlitchClass('glitch-in');
       setVisible(true);
@@ -146,7 +166,7 @@ const GlitchingMessages = () => {
         }, 1000);
       }, Math.random() * 3500 + 1500);
     }
-  }, [visible, messages, glitchTransitions]);
+  }, [visible, messages, glitchTransitions, messageColor, colorOptions]);
 
   useEffect(() => {
     // Check for showing/hiding message every 1.5-5 seconds (more frequent)
@@ -158,7 +178,15 @@ const GlitchingMessages = () => {
   if (!visible) return null;
 
   return (
-    <div className={`glitching-message ${glitchClass}`} data-text={currentMessage}>
+    <div
+      className={`glitching-message ${glitchClass}`}
+      data-text={currentMessage}
+      style={{
+        color: messageColor,
+        textShadow: `0 0 5px ${messageColor}`,
+        '--message-color': messageColor
+      }}
+    >
       {currentMessage}
     </div>
   );


### PR DESCRIPTION
## Summary
- vary glitch message color each time they're shown so they stand out
- allow CSS to inherit the new color via a variable

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c83c123bc83239111aa5f92002028