### PR TITLE
Add weekly summary email support

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import GlitchingMessagesWrapper from './GlitchingMessagesWrapper';
 import GlitchingCountdown from './GlitchingCountdown';
 import ChallengeManager from './ChallengeManager';
 import { calculateDaysUntilEvent } from './TimeUtils';
+import { checkAndSendWeeklySummary } from './WeeklySummaryService';
 
 function App() {
   const [progress, setProgress] = useState(75);
@@ -34,6 +35,11 @@ function App() {
     const timer = setInterval(updateTimings, 60000);
 
     return () => clearInterval(timer);
+  }, []);
+
+  // Check if a weekly summary email should be sent
+  useEffect(() => {
+    checkAndSendWeeklySummary();
   }, []);
 
   useEffect(() => {

--- a/src/WeeklySummaryService.js
+++ b/src/WeeklySummaryService.js
@@ -1,0 +1,32 @@
+import { sendWeeklySummaryEmail } from './EmailService';
+
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+export const checkAndSendWeeklySummary = async () => {
+  try {
+    const now = new Date();
+    const lastSent = localStorage.getItem('lastWeeklySummarySent');
+    const lastDate = lastSent ? new Date(lastSent) : null;
+    if (lastDate && now - lastDate < ONE_WEEK_MS) {
+      return;
+    }
+
+    const history = JSON.parse(localStorage.getItem('completionHistory') || '[]');
+    const weekStart = new Date(now.getTime() - ONE_WEEK_MS);
+    const events = history.filter(e => new Date(e.timestamp) >= weekStart);
+    if (events.length === 0) {
+      localStorage.setItem('lastWeeklySummarySent', now.toISOString());
+      return;
+    }
+
+    await sendWeeklySummaryEmail(
+      events,
+      weekStart.toLocaleDateString(),
+      now.toLocaleDateString()
+    );
+    localStorage.setItem('lastWeeklySummarySent', now.toISOString());
+  } catch (error) {
+    console.error('Error in weekly summary service:', error);
+  }
+};
+


### PR DESCRIPTION
## Summary
- log completion events for weekly summaries
- add weekly summary mailer service
- check for summary emails on app load

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eade3577c8323962d1b1c807f7329