### PR TITLE
Force final stage display with photo challenge

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,10 +23,10 @@ function App() {
 
   useEffect(() => {
     const updateTimings = () => {
-      setDaysLeft(calculateDaysUntilEvent());
-      
-      const savedLocationStage = localStorage.getItem('locationStage');
-      const stage = savedLocationStage ? parseInt(savedLocationStage, 10) : 0;
+      setDaysLeft(0);
+
+      const stage = 6;
+      localStorage.setItem('locationStage', '6');
       setLocationStage(stage);
       setProgress(calculateLocationProgress(stage));
     };
@@ -82,6 +82,8 @@ function App() {
       if (!localStorage.getItem('treasureChestUnlocked')) {
         localStorage.setItem('treasureChestUnlocked', 'true');
       }
+
+      localStorage.setItem('locationStage', '6');
     };
 
     initializeCompletedStages();

--- a/src/ChallengeManager.js
+++ b/src/ChallengeManager.js
@@ -6,7 +6,7 @@ import DailyEmojiGuesser from './DailyEmojiGuesser';
 import RosewoodRumor from './RosewoodRumor';
 
 const ChallengeManager = () => {
-  const [locationStage, setLocationStage] = useState(0);
+  const [locationStage, setLocationStage] = useState(6);
   const [isLoading, setIsLoading] = useState(true);
   
   useEffect(() => {

--- a/src/LocationTracker.js
+++ b/src/LocationTracker.js
@@ -80,24 +80,18 @@ const LocationTracker = () => {
     }
   ], []);
 
-  // Load saved progress
+  // Load progress (forced to final stage)
   useEffect(() => {
-    const savedStage = localStorage.getItem('locationStage');
-    const savedDistance = localStorage.getItem('currentDistance');
-    const savedUpdate = localStorage.getItem('lastLocationUpdate');
-    const savedPasswordState = localStorage.getItem('treasurePasswordVerified');
-    
-    if (savedStage) setLocationStage(parseInt(savedStage, 10));
-    if (savedDistance) setCurrentDistance(parseFloat(savedDistance));
-    if (savedUpdate) setLastUpdate(new Date(savedUpdate));
-    if (savedPasswordState === 'true') setPasswordVerified(true);
+    setLocationStage(6);
+    setCurrentDistance(0);
+    setHasLocationPermission(true);
+    setLastUpdate(new Date());
+    localStorage.setItem('locationStage', '6');
+    localStorage.setItem('currentDistance', '0');
+    localStorage.setItem('lastLocationUpdate', new Date().toISOString());
 
-    if (navigator.permissions) {
-      navigator.permissions.query({ name: 'geolocation' }).then(result => {
-        setHasLocationPermission(result.state === 'granted');
-        setPermissionDenied(result.state === 'denied');
-      });
-    }
+    const savedPasswordState = localStorage.getItem('treasurePasswordVerified');
+    if (savedPasswordState === 'true') setPasswordVerified(true);
   }, []);
 
   // Simple hint cycling effect - just sets active hint index


### PR DESCRIPTION
## Summary
- always set location stage to 6 and days left to 0
- show photo challenge link regardless of real location

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb5b84e54832394b773c846dd357c