### PR TITLE
Fix unused lint import

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,6 @@ import AnimatedShip from './AnimatedShip';
 import GlitchingMessagesWrapper from './GlitchingMessagesWrapper';
 import GlitchingCountdown from './GlitchingCountdown';
 import ChallengeManager from './ChallengeManager';
-import { calculateDaysUntilEvent } from './TimeUtils';
 import { checkAndSendWeeklySummary } from './WeeklySummaryService';
 
 function App() {


### PR DESCRIPTION
## Summary
- remove unused `calculateDaysUntilEvent` import

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb962bf1c8323a7633d1f887f316a