### PR TITLE
Hide treasure location

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -45,7 +45,7 @@ function App() {
     const glitchTimer = setTimeout(() => {
       setWatcherGlitch(true);
       setTimeout(() => {
-        setWatcherMessage('Lido Adriano is watching. -A');
+        setWatcherMessage('Someone is watching. -A');
         setWatcherGlitch(false);
       }, 200);
     }, 1500);
@@ -141,7 +141,7 @@ function App() {
           <span className="status-value">
             {locationStage === 0 && "Ready for Journey"}
             {locationStage > 0 && locationStage < 6 && "En Route to Italy"}
-            {locationStage >= 6 && "Treasure Found!"}
+            {locationStage >= 6 && "Head to Photo Challenge"}
           </span>
         </div>
       </div>

--- a/src/ChallengeManager.js
+++ b/src/ChallengeManager.js
@@ -96,22 +96,19 @@ const ChallengeManager = () => {
         </p>
       </div>
 
-      {/* Final Treasure Message when at location */}
+      {/* Final message when at location */}
       {locationStage >= 6 && (
         <div className="final-treasure-section compact">
-          <h3>🌅 Treasure Found!</h3>
+          <h3>🌅 You've Arrived!</h3>
           <div className="treasure-message">
-            <p>🎉 You've reached the exact treasure location! The physical chest containing your Italian adventure rewards is within reach.</p>
-            <div className="final-coordinates compact">
-              <strong>📍 Lido Adriano, Italy</strong>
-            </div>
+            <p>🎉 Great job reaching the final stop. Your next mission is waiting.</p>
             <p className="polaroid-link">
               <a
                 href="https://photochallange.netlify.app"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                📸 Begin the Polaroid Challenge
+                📸 Head to the Polaroid Challenge
               </a>
             </p>
           </div>

--- a/src/GlitchingMessages.js
+++ b/src/GlitchingMessages.js
@@ -8,8 +8,8 @@ const GlitchingMessages = () => {
   const [glitchClass, setGlitchClass] = useState('');
   const glitchTransitions = useMemo(
     () => ({
-      "rosewood's secrets always surface. -A": "Lido Adriano's secrets always surface. -A",
-      "meet me in Rosewood's town square. -A": "meet me in Lido Adriano's town square. -A",
+      "rosewood's secrets always surface. -A": "the seaside town's secrets always surface. -A",
+      "meet me in Rosewood's town square. -A": "meet me in the seaside town's square. -A",
     }),
     []
   );
@@ -21,7 +21,7 @@ const GlitchingMessages = () => {
     "time's almost up, better confess. -A",
     "tick-tock, bitches. -A",
     "i know everything you're hiding. -A",
-    "Lido Adriano's secrets always surface. -A",
+    "this town's secrets always surface. -A",
     "hanna's heels can't outrun me. -A",
     "spencer won't puzzle this out in time. -A",
     "aria's typewriter can't rewrite your past. -A",

--- a/src/LocationTracker.js
+++ b/src/LocationTracker.js
@@ -19,7 +19,7 @@ const LocationTracker = () => {
     lng: -0.431901
   };
 
-  // Target coordinates (Lido Adriano, Italy)
+  // Target coordinates (secret location)
   const targetCoords = {
     lat: 44.424156,
     lng: 12.304828
@@ -62,19 +62,19 @@ const LocationTracker = () => {
       icon: '🌊',
       hint: 'Sparkling waters'
     },
-    { 
-      id: 5, 
-      name: 'Lido Adriano', 
-      threshold: 5, 
+    {
+      id: 5,
+      name: 'The Beach',
+      threshold: 5,
       icon: '🏖️',
       hint: 'Almost there'
     },
-    { 
-      id: 6, 
-      name: 'Treasure Found!', 
-      threshold: 0, 
+    {
+      id: 6,
+      name: 'Final Stop',
+      threshold: 0,
       icon: '💎',
-      hint: 'X marks the spot'
+      hint: 'Challenge awaits'
     }
   ], []);
 
@@ -271,7 +271,7 @@ const LocationTracker = () => {
           <div className="treasure-icon">🧭</div>
           <h3>Begin Treasure Hunt</h3>
           <p>Follow the ancient map from Home to the Italian treasure.</p>
-          <p><strong>Destination:</strong> Lido Adriano, Italy</p>
+          <p><strong>Destination:</strong> Secret Location</p>
           <button 
             className="permission-btn golden" 
             onClick={requestLocationPermission}
@@ -332,7 +332,7 @@ const LocationTracker = () => {
         
         <div className="progress-labels">
           <span>🏠 Home</span>
-          <span>🏖️ Lido Adriano</span>
+          <span>🏖️ Destination</span>
         </div>
       </div>
 
@@ -358,24 +358,7 @@ const LocationTracker = () => {
 
       {/* Hint Popup - removed, now using CSS ::after on markers */}
 
-      {/* Final Coordinates */}
-      {locationStage >= 6 && (
-        <div className="treasure-coords">
-          <div className="coords-revealed">
-            <div className="coords-label">📍 Treasure Coordinates:</div>
-            <div className="coords-text">
-              <a
-                href="https://www.google.com/maps?q=44.424156,12.304828"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                44.424156, 12.304828
-              </a>
-            </div>
-            <div className="coords-location">Lido Adriano, Italy</div>
-          </div>
-        </div>
-      )}
+      {/* Final coordinates removed to keep location secret */}
 
       {lastUpdate && (
         <div className="last-update">

--- a/src/RosewoodRumor.js
+++ b/src/RosewoodRumor.js
@@ -4,13 +4,13 @@ import './RosewoodRumor.css';
 const RosewoodRumor = () => {
   const facts = useMemo(
     () => [
-      "A certain clique in Lido Adriano can't seem to escape trouble.",
+      "A certain clique in this seaside town can't seem to escape trouble.",
       'Anonymous messages hold more weight than gossip in this small town.',
-      "The bell tower has witnessed more drama than most places in Lido Adriano.",
+      "The bell tower has witnessed more drama than most places in town.",
       'Masked gatherings rarely end calmly here.',
-      'Secrets buried in Lido Adriano never stay hidden for long.',
+      'Secrets buried here never stay hidden for long.',
       'Mysterious texts keep everyone guessing.',
-      "Friendships are tested daily in Lido Adriano's halls.",
+      "Friendships are tested daily in these halls.",
       'Every clue brings an A-plus puzzle with it.',
       "Someone's bold new hair color is stirring the rumor mill."
     ],


### PR DESCRIPTION
## Summary
- remove explicit coordinates in location tracker and keep them secret
- show "Head to Photo Challenge" when arriving instead of "Treasure Found"
- update status text and glitch messages to avoid revealing the destination
- sanitize location references in rumors

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bfd40d65883239990366553519fa3